### PR TITLE
Removed the word "advertisement"

### DIFF
--- a/words/objects.txt
+++ b/words/objects.txt
@@ -15,7 +15,6 @@ addition
 address
 adjustment
 advantage
-advertisement
 aftermath
 afternoon
 aftershave


### PR DESCRIPTION
Adblocks might block examples, ressources in a glitch project or more, containing the word in the glitch's subdomain.
(happened to me with uBlock origin).
Might not look good to visitors / new users on first sight and requires multiple manual unblockings.
https://u.cubeupload.com/Blubbll/tGsDlR.png