### PR TITLE
Remove hanging from predicates

### DIFF
--- a/words/predicates.txt
+++ b/words/predicates.txt
@@ -493,7 +493,6 @@ halved
 handsome
 handsomely
 handy
-hanging
 happy
 harmonious
 harsh


### PR DESCRIPTION
The word "hanging" can be triggering and/or result in violent-sounding team names