### PR TITLE
remove node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "lodash.samplesize": "^4.2.0",
     "ava": "^0.25.0"
   },
-  "engines": {
-    "node": "10.x"
-  },
   "repository": {
     "url": "https://github.com/FogCreek/friendly-words"
   },


### PR DESCRIPTION
The node 10.x restriction was preventing use with node 11, but it works fine with node 11! Seems simplest just to remove that restriction.